### PR TITLE
Add download_model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ docs/site/
 # committed for packages, but should be committed for applications that require a static
 # environment.
 Manifest.toml
+
+# Ignore any models saved in the models/ folder
+models/**

--- a/Project.toml
+++ b/Project.toml
@@ -5,12 +5,21 @@ version = "0.2.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+Downloads = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
 ReplMaker = "b873ce64-0db9-51f5-a568-4457d8e49576"
-Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 llama_cpp_jll = "98bd2d0b-bc7c-583a-ba54-7299b0ad0e7f"
 
 [compat]
+Aqua = "0.7"
 CEnum = "0.5"
+Downloads = "1.5, 1.6"
 ReplMaker = "0.2"
 julia = "1.9"
 llama_cpp_jll = "= 0.0.15"
+
+[extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[targets]
+test = ["Aqua", "Test"]

--- a/README.md
+++ b/README.md
@@ -30,6 +30,19 @@ LLaMA, are freely available.  They can be downloaded here in GGML
 format (choose one of the .bin files):
 https://huggingface.co/SlyEcho/open_llama_3b_v2_ggml
 
+Explore other models on the [HuggingFace Hub](https://huggingface.co).
+
+Once you have a `url` link to a `.gguf` file, you can simply download it via:
+
+```julia
+using Llama
+
+# Example for an Open-chat 7Bn parameter model (c. 4.4GB)
+url = "https://huggingface.co/TheBloke/openchat-3.5-0106-GGUF/resolve/main/openchat-3.5-0106.Q4_K_M.gguf"
+model = download_model(url)
+# Output: "models/openchat-3.5-0106.Q4_K_M.gguf"
+```
+You can use the model variable directly in the `run_*` functions, like `run_server`.
 
 ## REPL mode
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Llama.jl
 
 [![Build Status](https://github.com/marcom/Llama.jl/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/marcom/Llama.jl/actions/workflows/ci.yml?query=branch%3Amain)
+[![Aqua](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 
 Julia interface to
 [llama.cpp](https://github.com/ggerganov/llama.cpp), a C/C++ port of

--- a/src/Llama.jl
+++ b/src/Llama.jl
@@ -1,6 +1,6 @@
 module Llama
 
-export run_llama, run_chat
+export run_llama, run_chat, run_server, download_model
 export LlamaContext, embeddings, llama_eval, logits, tokenize,
     token_to_str
 

--- a/src/Llama.jl
+++ b/src/Llama.jl
@@ -6,13 +6,14 @@ export LlamaContext, embeddings, llama_eval, logits, tokenize,
 
 import llama_cpp_jll
 import ReplMaker
+import Downloads
 
 include("../lib/LibLlama.jl")
 import .LibLlama
 
 __init__() = isdefined(Base, :active_repl) ? init_repl() : nothing
 
-
+include("utils.jl")
 include("api.jl")
 include("run-programs.jl")
 include("repl.jl")

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,0 +1,26 @@
+"""
+    download_model(url::AbstractString; dir::AbstractString="models")
+
+Downloads a model specified by `url` from the HuggingFace Hub into `dir` directory and returns the path to the downloaded file.
+
+Note: Currently works only for models in the GGUF format (expects the URL to end with `.gguf`).
+
+See [HuggingFace Model Hub](https://huggingface.co/models) for a list of available models.
+
+# Examples
+```julia
+# Download the Rocket model (~1GB)
+url = "https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf"
+model = download_model(url) 
+# Output: "models/rocket-3b-2.76bpw.gguf"
+```
+"""
+function download_model(url::AbstractString; dir::AbstractString="models")
+    @assert startswith(url, "https://huggingface.co/") || startswith(url, "http://huggingface.co/") "The provided URL is not a HuggingFace Hub model. See https://huggingface.co/"
+    @assert endswith(url, ".gguf") "The provided URL is not in the GGUF format. File name: $(splitpath(url)[end])"
+
+    model_fn = joinpath(dir, splitpath(url)[end]) # target file name
+    mkpath(dirname(model_fn)) # ensure it exists
+    Downloads.download(url, model_fn) # download the model
+    return model_fn # return the path to the downloaded file
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -1,9 +1,10 @@
 """
     download_model(url::AbstractString; dir::AbstractString="models")
 
-Downloads a model specified by `url` from the HuggingFace Hub into `dir` directory and returns the path to the downloaded file.
+Downloads a model specified by `url` from the HuggingFace Hub into `dir` directory and returns the `model_path` to the downloaded file.
+If the `dir` directory does not exist, it will be created.
 
-Note: Currently works only for models in the GGUF format (expects the URL to end with `.gguf`).
+Note: Currently allows only models in the GGUF format (expects the URL to end with `.gguf`).
 
 See [HuggingFace Model Hub](https://huggingface.co/models) for a list of available models.
 
@@ -16,11 +17,15 @@ model = download_model(url)
 ```
 """
 function download_model(url::AbstractString; dir::AbstractString="models")
-    @assert startswith(url, "https://huggingface.co/") || startswith(url, "http://huggingface.co/") "The provided URL is not a HuggingFace Hub model. See https://huggingface.co/"
-    @assert endswith(url, ".gguf") "The provided URL is not in the GGUF format. File name: $(splitpath(url)[end])"
+    if !endswith(url, ".gguf")
+        throw(ArgumentError("The provided URL is not in the GGUF format. File name: $(splitpath(url)[end])"))
+    end
+    if !(startswith(url, "https://huggingface.co/") || startswith(url, "http://huggingface.co/"))
+        @warn "Potential error. The provided URL seems to not be from the HuggingFace Hub. See https://huggingface.co/ to double-check the link."
+    end
 
-    model_fn = joinpath(dir, splitpath(url)[end]) # target file name
-    mkpath(dirname(model_fn)) # ensure it exists
-    Downloads.download(url, model_fn) # download the model
-    return model_fn # return the path to the downloaded file
+    model_path = joinpath(dir, splitpath(url)[end])
+    mkpath(dirname(model_path))
+    Downloads.download(url, model_path)
+    return model_path
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,15 @@
 using Test
+using Aqua
 using Llama
 using Llama: LibLlama
 
 # show which testset is currently running
 showtestset() = println(" "^(2 * Test.get_testset_depth()), "testing ",
-                        Test.get_testset().description)
+    Test.get_testset().description)
+
+@testset "Code quality (Aqua.jl)" begin
+    # Skipping unbound_args check because we need our `MaybeExtract` type to be unboard
+    Aqua.test_all(Llama)
+end
 
 include("run-programs.jl")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,4 +12,7 @@ showtestset() = println(" "^(2 * Test.get_testset_depth()), "testing ",
     Aqua.test_all(Llama)
 end
 
-include("run-programs.jl")
+@testset "Llama.jl" begin
+    include("utils.jl")
+    include("run-programs.jl")
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,0 +1,8 @@
+using Llama: download_model
+@testset "download_model" begin
+    # pytorch .bin model suffix
+    @test_throws AssertionError download_model("https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.bin")
+    # not from huggingface
+    @test_throws AssertionError download_model("https://google.com/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf")
+    # Note: not testing the actual download because it's slow and wasteful
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,8 +1,12 @@
 using Llama: download_model
 @testset "download_model" begin
     # pytorch .bin model suffix
-    @test_throws AssertionError download_model("https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.bin")
+    @test_throws ArgumentError download_model("https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.bin")
     # not from huggingface
-    @test_throws AssertionError download_model("https://google.com/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf")
+    log = "Potential error. The provided URL seems to not be from the HuggingFace Hub. See https://huggingface.co/ to double-check the link."
+    @test_logs (:warn, log) try
+        download_model("https://google.com/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf")
+    catch _
+    end
     # Note: not testing the actual download because it's slow and wasteful
 end


### PR DESCRIPTION
This PR adds a small utility to make it super easy to download hugging face models locally. 
It introduces a dependency, but it's fairly standard and lightweight.

```julia
# Download the Rocket model (~1GB)
url = "https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf"
model = download_model(url) 
# Output: "models/rocket-3b-2.76bpw.gguf"
```

It's quite restrictive (URL checks) to avoid common pitfalls for first-time users.

As part of the PR, I was checking tests, so I've added Aqua and its badge. 
Happy to remove it but it's a good practice to have it?
(the movements in Project.toml are because of Aqua standards)