### PR TITLE
Update llama.cpp to the latest version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 ### Fixed
 
+## [0.4.0]
+
+### Updated
+- Updated `llama.cpp` to `0.0.17` (b4371) for better performance, stability and new features.
+- Updated `llama_cpp_jll` binaries to use `llama_cli` and `llama_server` instead of `main` and `server`.
+
 ## [0.3.0]
 
 ### Added

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Llama"
 uuid = "882c185a-eef0-4636-aa0b-94c4dba13695"
 authors = ["Marco Matthies <71844+marcom@users.noreply.github.com>"]
-version = "0.3.0"
+version = "0.4.0"
 
 [deps]
 CEnum = "fa961155-64e5-5f13-b03f-caf6b980ea82"
@@ -15,7 +15,7 @@ CEnum = "0.5"
 Downloads = "1.5, 1.6"
 ReplMaker = "0.2"
 julia = "1.9"
-llama_cpp_jll = "= 0.0.16"
+llama_cpp_jll = "= 0.0.17"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ You will need a file with quantized model weights in the right format (GGUF).
 
 You can either download the weights from the [HuggingFace Hub](https://huggingface.co) (search for "GGUF" to download the right format) or convert them from the original PyTorch weights (see [llama.cpp](https://github.com/ggerganov/llama.cpp) for instructions.)
 
-Good weights to start with are the Dolphin-family fine-tuned weights, which are Apache 2.0 licensed and can be downloaded [here](https://huggingface.co/TheBloke/dolphin-2.6-mistral-7B-dpo-GGUF). Click on the tab "Files" and download one of the `*.gguf` files. We recommend the Q4_K_M version (~4.4GB).
+Good weights to start with are the Llama3-family fine-tuned weights ([here](https://huggingface.co/bartowski/Meta-Llama-3.1-8B-Instruct-GGUF) with a Llama-specific licence) or Qwen 2.5 family, which are Apache 2.0 licensed and can be downloaded [here](https://huggingface.co/Qwen/Qwen2.5-Coder-7B-Instruct-GGUF). Click on the tab "Files" and download one of the `*.gguf` files. We recommend the Q5_K_M version (~5.5GB).
 
 In the future, there might be new releases, so you might want to check for new versions.
 
@@ -35,10 +35,10 @@ Once you have a `url` link to a `.gguf` file, you can simply download it via:
 
 ```julia
 using Llama
-# Example for a 7Bn parameter model (c. 4.4GB)
-url = "https://huggingface.co/TheBloke/dolphin-2.6-mistral-7B-dpo-GGUF/resolve/main/dolphin-2.6-mistral-7b-dpo.Q4_K_M.gguf"
+# Example for a 360M parameter model (c. 0.3GB)
+url = "https://huggingface.co/bartowski/SmolLM2-360M-Instruct-GGUF/resolve/main/SmolLM2-360M-Instruct-Q5_K_S.gguf"
 model = download_model(url)
-# Output: "models/dolphin-2.6-mistral-7b-dpo.Q4_K_M.gguf"
+# Output: "models/SmolLM2-360M-Instruct-Q5_K_S.gguf"
 ```
 
 You can use the model variable directly in the `run_*` functions, like `run_server`.
@@ -56,15 +56,18 @@ using Llama
 Llama.run_server(; model)
 ```
 
+Just open the URL `http://127.0.0.1:10897` in your browser to see the chat interface or use GET requests to the `/v1/chat/completions` endpoint.
+
 ### Llama Text Generation
 
 ```julia
 using Llama
+model = "models/SmolLM2-360M-Instruct-Q5_K_S.gguf"
 
-s = run_llama(model="models/dolphin-2.6-mistral-7b-dpo.Q4_K_M.gguf", prompt="Hello")
+s = run_llama(; model, prompt="Hello")
 
 # Provide additional arguments to llama.cpp (check the documentation for more details or the help text below)
-s = run_llama(model="models/dolphin-2.6-mistral-7b-dpo.Q4_K_M.gguf", prompt="Hello", n_gpu_layers=0, args=`-n 16`)
+s = run_llama(; model, prompt="Hello", n_gpu_layers=0, args=`-n 16`)
 
 # print the help text with more options
 run_llama(model="", prompt="", args=`-h`)
@@ -77,7 +80,7 @@ run_llama(model="", prompt="", args=`-h`)
 ### Interactive chat mode
 
 ```julia
-run_chat(model="models/dolphin-2.6-mistral-7b-dpo.Q4_K_M.gguf", prompt="Hello chat mode")
+run_chat(; model, prompt="Hello chat mode")
 ```
 
 ## REPL mode

--- a/src/run-programs.jl
+++ b/src/run-programs.jl
@@ -27,7 +27,7 @@ function run_llama(;
         n_gpu_layers::Int = 99,
         ctx_size::Int = 2048,
         args = ``)
-    cmd = `$(llama_cpp_jll.main()) --model $model --prompt $prompt --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $args`
+    cmd = `$(llama_cpp_jll.llama_cli()) --model $model --prompt $prompt --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $args`
     if Sys.isapple()
         # Provides the path to locate ggml-metal.metal file (must be provided separately)
         cmd = addenv(cmd,
@@ -71,7 +71,7 @@ function run_chat(;
         n_gpu_layers::Int = 99,
         ctx_size::Int = 2048,
         args = ``)
-    cmd = `$(llama_cpp_jll.main()) --model $model --prompt $prompt --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $args -ins`
+    cmd = `$(llama_cpp_jll.llama_cli()) --model $model --prompt $prompt --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $args -i`
     if Sys.isapple()
         # Provides the path to locate ggml-metal.metal file (must be provided separately)
         cmd = addenv(cmd,
@@ -133,7 +133,7 @@ function run_server(;
         embeddings::Bool = true,
         args = ``)
     embeddings_flag = embeddings ? `--embeddings` : ""
-    cmd = `$(llama_cpp_jll.server()) --model $model --host $host --port $port --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $(embeddings_flag) $args`
+    cmd = `$(llama_cpp_jll.llama_server()) --model $model --host $host --port $port --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $(embeddings_flag) $args`
     # Provides the path to locate ggml-metal.metal file (must be provided separately)
     # ggml-metal than requires ggml-common.h, which is in a separate folder, so we to add C_INCLUDE_PATH as well
     cmd = addenv(


### PR DESCRIPTION
- Updated `llama.cpp` to `0.0.17` (b4371) for better performance, stability and new features.
- Updated `llama_cpp_jll` binaries to use `llama_cli` and `llama_server` instead of `main` and `server`.
- Updated README models to Llama 3 series and Qwen 2.5 + changed examples to use Smol2 models for quick download (300MB)
