### PR TITLE
Disable embeddings in run_server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ Manifest.toml
 
 # Ignore any models saved in the models/ folder
 models/**
+
+## ignore scratch files
+_*.jl

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 - Updated `llama.cpp` to `0.0.17` (b4371) for better performance, stability and new features.
 - Updated `llama_cpp_jll` binaries to use `llama_cli` and `llama_server` instead of `main` and `server`.
 
+### Fixed
+- Fixed `run_server` command to disallow embeddings by default (some models do not support it and it might break the server).
+
 ## [0.3.0]
 
 ### Added

--- a/src/run-programs.jl
+++ b/src/run-programs.jl
@@ -102,7 +102,8 @@ Interrupt the server with `Ctrl+C`.
 - `n_gpu_layers`: number of layers to offload on the GPU (a.k.a. `ngl` in llama.cpp). Requires more VRAM on your GPU but can speed up inference.
   Set to 0 to run inference on CPU-only. Defaults to 99 (=practically all layers)
 - `ctx_size`: context size, ie, how big can the prompt/inference be. Defaults to 2048 (but most models allow 4,000 and more)
-- `embeddings`: whether to allow generating of embeddings. Defaults to `true`
+- `embeddings`: whether to allow generating of embeddings. Defaults to `false`.
+   Note: Embeddings are not supported by all models and it might break the server!
 - `args`: additional arguments to pass to the server
 
 See the [full documentation](https://github.com/ggerganov/llama.cpp/blob/master/examples/server/README.md) for more details.
@@ -130,10 +131,10 @@ function run_server(;
         nthreads::Int = Threads.nthreads(),
         n_gpu_layers::Int = 99,
         ctx_size::Int = 2048,
-        embeddings::Bool = true,
+        embeddings::Bool = false,
         args = ``)
-    embeddings_flag = embeddings ? `--embeddings` : ""
-    cmd = `$(llama_cpp_jll.llama_server()) --model $model --host $host --port $port --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size $(embeddings_flag) $args`
+    embeddings_flag = embeddings ? ` --embeddings` : ""
+    cmd = `$(llama_cpp_jll.llama_server()) --model $model --host $host --port $port --threads $nthreads --n-gpu-layers $n_gpu_layers --ctx-size $ctx_size$(embeddings_flag) $args`
     # Provides the path to locate ggml-metal.metal file (must be provided separately)
     # ggml-metal than requires ggml-common.h, which is in a separate folder, so we to add C_INCLUDE_PATH as well
     cmd = addenv(


### PR DESCRIPTION
This PR disables the embeddings flag in `run_server` command.
Added a comment in the docstring to make it clear.

Otherwise, it breaks the server for some models (new behaviour?).

Since this is a bug fix -- I'll push it through.

@marcom for visibility!

How to test:
```
using Llama

# URL for the Rocket 1GB model
url = "https://huggingface.co/ikawrakow/various-2bit-sota-gguf/resolve/main/rocket-3b-2.76bpw.gguf"

# Download the model
model = download_model(url)

# Run the server with the model
Llama.run_server(; model = model)

# open in browser http://127.0.0.1:10897/ and chat!
```
Or in PromptingTools.jl
```
using PromptingTools
ai"say hi"local

# or the full version 
msg = aigenerate("say hi", model="local")
# model="local" is an alias that routes the queries towards your Llama.jl server
```